### PR TITLE
C++ forbids variable length array

### DIFF
--- a/src/serial_reader.cpp
+++ b/src/serial_reader.cpp
@@ -79,7 +79,7 @@ SerialReader::SerialReader(const std::string &serial_port, const int &num_values
 void SerialReader::loop()
 {
     int byte_read;
-    int buffer_size = 128;
+    const int buffer_size = 128;
     char buffer[buffer_size];
     char line[buffer_size];
     int line_index = 0;


### PR DESCRIPTION
[//]: # "Thanks for your contribution.  To make life of the reviewers easier,"
[//]: # "please give this pull request a meaningful title and provide the"
[//]: # "requested information below."

## Description

[//]: # "Description of what you did.  If it is more complex, consider to add a"
[//]: # "'Summary' section."
I made the ```buffer_size``` variable a ```const```.

## How I Tested

[//]: # "Explain how you tested your changes"
 
The compiler no longers outputs ```warning: ISO C++ forbids variable length array ...``` after this change.

## Notes

For variable length arrays, you need to do 
```C++ 
char buffer = new char[buffer_size];
```
instead of 
```C++
char buffer[buffer_size];
```
but I think it's easier to just add ```const``` in this situation.