### PR TITLE
Change auto-detection behaviour in SerialReader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,23 +5,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-### Added
-- New features
-
 ### Changed
-- Changes in existing functionality.
+- Changed auto-detection behaviour of serial port in `SerialReader`.  The old
+  behaviour was to always first attempt to auto-detect and only consider the
+  port provided by the user if this fails.  The new behaviour depends on the
+  value of the `serial_port` argument:
 
-### Deprecated
-- for soon-to-be removed features.
-
-### Removed
-- for now removed features.
-
-### Fixed
-- Bugfixes
-
-### Security
-- in case of vulnerabilities.
+  - Empty or "auto": Try to auto-detect the port.
+  - any other value: Try to open the specified port.  Do not attempt to
+    auto-detect.
 
 
 ## [1.0.0] - 2022-11-16

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,9 +31,15 @@ find_package(mpi_cmake_modules REQUIRED)
 find_package(real_time_tools REQUIRED)
 find_package(rt REQUIRED)
 find_package(Threads REQUIRED)
+find_package(fmt REQUIRED)
+find_package(spdlog REQUIRED)
 
 # Export de dependencies.
-ament_export_dependencies(real_time_tools)
+ament_export_dependencies(
+    real_time_tools
+    spdlog
+    fmt
+)
 
 # Prepare the final export.
 set(all_targets)
@@ -69,8 +75,12 @@ endif()
 
 # Link the catkin dependencies.
 ament_target_dependencies(${PROJECT_NAME} rt)
-target_link_libraries(${PROJECT_NAME} real_time_tools::real_time_tools)
-target_link_libraries(${PROJECT_NAME} Threads::Threads)
+target_link_libraries(${PROJECT_NAME}
+    real_time_tools::real_time_tools
+    Threads::Threads
+    fmt::fmt
+    spdlog::spdlog
+)
 
 # If on xenomai we need to link to the real time os librairies.
 if(Xenomai_FOUND)

--- a/demos/basic.cpp
+++ b/demos/basic.cpp
@@ -1,7 +1,7 @@
+#include <signal.h>
 #include <unistd.h>
 #include <cstdlib>
 #include <iostream>
-#include <signal.h>
 
 #include "real_time_tools/timer.hpp"
 
@@ -12,9 +12,10 @@ using namespace std;
 bool keep_running = true;
 
 // Define the function to be called when ctrl-c (SIGINT) is sent to process.
-void signal_callback_handler(int signum) {
-   // Terminate program
-   keep_running = false;
+void signal_callback_handler(int signum)
+{
+    // Terminate program
+    keep_running = false;
 }
 
 /**

--- a/include/slider_box/serial_reader.hpp
+++ b/include/slider_box/serial_reader.hpp
@@ -14,6 +14,8 @@
 #include <mutex>
 #include <vector>
 
+#include <spdlog/spdlog.h>
+
 #include "real_time_tools/thread.hpp"
 
 namespace slider_box
@@ -36,6 +38,8 @@ public:
      */
     int fill_vector(std::vector<int>& values);
 
+    inline static const std::string LOGGER_NAME = "SerialReader";
+
 private:
     /**
      * @brief This is the helper function used for spawning the real time
@@ -55,6 +59,8 @@ private:
      * main board.
      */
     void loop();
+
+    std::shared_ptr<spdlog::logger> log_;
 
     /**
      * @brief This boolean makes sure that the loop is stopped upon destruction

--- a/include/slider_box/serial_reader.hpp
+++ b/include/slider_box/serial_reader.hpp
@@ -1,10 +1,8 @@
 /**
- * \file
- * \brief Wrapper for reading new-line terminated list of values from serial
- * port.
- * \author Julian Viereck
- * \date 2020
- * \copyright Copyright (c) 2020, New York University & Max Planck Gesellschaft
+ * @file
+ * @brief Class for reading new-line terminated list of values from serial port.
+ * @author Julian Viereck
+ * @copyright Copyright (c) 2020, New York University & Max Planck Gesellschaft
  */
 #pragma once
 
@@ -23,9 +21,14 @@ namespace slider_box
 class SerialReader
 {
 public:
+    //! @brief Name of the spdlog logger used by the class.
+    inline static const std::string LOGGER_NAME = "SerialReader";
+
     /**
-     * @param serial_port The address of the serial port to use.
-     * @pparam num_values The number of values to read in each line.
+     * @param serial_port The address of the serial port to use.  Set to ""
+     *      (empty string) or "auto" to auto-detect the port.
+     * @param num_values The number of values to read in each line.
+     * @throws std::runtime_error if opening the port fails.
      */
     SerialReader(const std::string& serial_port, const int& num_values);
 
@@ -38,9 +41,18 @@ public:
      */
     int fill_vector(std::vector<int>& values);
 
-    inline static const std::string LOGGER_NAME = "SerialReader";
-
 private:
+    /**
+     * @brief Open the specified port.
+     *
+     * Sets fd_.
+     *
+     * @param port Name of the serial port.
+     *
+     * @return True on success.
+     */
+    bool open_port(const std::string& port);
+
     /**
      * @brief This is the helper function used for spawning the real time
      * thread.
@@ -89,9 +101,6 @@ private:
      */
     bool is_active_;
 
-    /**
-     *
-     */
     int new_data_counter_;
 
     int missed_data_counter_;

--- a/include/slider_box/serial_reader.hpp
+++ b/include/slider_box/serial_reader.hpp
@@ -1,25 +1,23 @@
 /**
  * \file
- * \brief Wrapper for reading new-line terminated list of values from serial port.
+ * \brief Wrapper for reading new-line terminated list of values from serial
+ * port.
  * \author Julian Viereck
  * \date 2020
- * \copyright Copyright (c) 2020, New York University and Max Planck
- *            Gesellschaft.
+ * \copyright Copyright (c) 2020, New York University & Max Planck Gesellschaft
  */
-
 #pragma once
 
+#include <unistd.h>
 #include <cstdlib>
 #include <iostream>
 #include <mutex>
-#include <unistd.h>
 #include <vector>
 
 #include "real_time_tools/thread.hpp"
 
 namespace slider_box
 {
-
 class SerialReader
 {
 public:
@@ -27,7 +25,7 @@ public:
      * @param serial_port The address of the serial port to use.
      * @pparam num_values The number of values to read in each line.
      */
-    SerialReader(const std::string &serial_port, const int &num_values);
+    SerialReader(const std::string& serial_port, const int& num_values);
 
     ~SerialReader();
 
@@ -98,9 +96,9 @@ private:
     std::vector<int> latest_values_;
 
     /**
-    * @brief mutex_ multithreading safety
-    */
+     * @brief mutex_ multithreading safety
+     */
     std::mutex mutex_;
 };
 
-}  // namespace blmc_drivers
+}  // namespace slider_box

--- a/package.xml
+++ b/package.xml
@@ -1,19 +1,26 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd"
-   schematypens="http://www.w3.org/2001/XMLSchema"?>
+schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
-<name>slider_box</name>
-<version>1.0.0</version>
-<description>Drivers for slider_box developed at https://github.com/open-dynamic-robot-initiative/slider_box</description>
-<maintainer email="jviereck@nyu.edu">Julian Viereck</maintainer>
-<license>BSD 3-clause</license>
-<buildtool_depend>ament_cmake</buildtool_depend>
-<!--  CMake module containing helper to find the OS, boost, python, etc.  -->
-<depend>mpi_cmake_modules</depend>
-<depend>real_time_tools</depend>
-<depend>rt</depend>
-<depend>Threads</depend>
-<test_depend>ament_cmake_gtest</test_depend>
-<export>
-<build_type>ament_cmake</build_type>
-</export>
+    <name>slider_box</name>
+    <version>1.0.0</version>
+    <description>Drivers for ODRI Slider Box</description>
+    <url>https://github.com/open-dynamic-robot-initiative/slider_box</url>
+    <maintainer email="jviereck@nyu.edu">Julian Viereck</maintainer>
+    <license>BSD 3-clause</license>
+
+    <buildtool_depend>ament_cmake</buildtool_depend>
+
+    <!--  CMake module containing helper to find the OS, boost, python, etc.  -->
+    <depend>mpi_cmake_modules</depend>
+    <depend>real_time_tools</depend>
+    <depend>rt</depend>
+    <depend>Threads</depend>
+    <depend>fmt</depend>
+    <depend>spdlog</depend>
+
+    <test_depend>ament_cmake_gtest</test_depend>
+
+    <export>
+        <build_type>ament_cmake</build_type>
+    </export>
 </package>

--- a/src/serial_reader.cpp
+++ b/src/serial_reader.cpp
@@ -1,7 +1,8 @@
 /**
  * @file serial_reader.cpp
  * @author Julian Viereck
- * \brief Wrapper for reading new-line terminated list of values from serial port.
+ * \brief Wrapper for reading new-line terminated list of values from serial
+ * port.
  * @date 2020-01-24
  *
  * @copyright Copyright (c) 2018
@@ -9,63 +10,78 @@
  */
 
 #include "slider_box/serial_reader.hpp"
-#include <stdexcept>
 #include <errno.h>
 #include <fcntl.h>
 #include <string.h>
 #include <termios.h>
 #include <unistd.h>
+#include <stdexcept>
 
-#include <iostream>
 #include <unistd.h>
 #include <fstream>
+#include <iostream>
 
 namespace rt = real_time_tools;
 
 namespace slider_box
 {
-
-SerialReader::SerialReader(const std::string &serial_port, const int &num_values)
+SerialReader::SerialReader(const std::string &serial_port,
+                           const int &num_values)
 {
     std::string serial_port_try;
-    for (int i=0; i < 4; ++i) {
+    for (int i = 0; i < 4; ++i)
+    {
         // HACK: Ignore the provided serial port and
-        if (i == 0) {
+        if (i == 0)
+        {
             serial_port_try = "/dev/ttyACM";
-        } else if (i == 1) {
+        }
+        else if (i == 1)
+        {
             serial_port_try = "/dev/ttyACM0";
-        } else if (i == 2) {
+        }
+        else if (i == 2)
+        {
             serial_port_try = "/dev/ttyACM1";
-        } else if (i == 3) {
+        }
+        else if (i == 3)
+        {
             serial_port_try = serial_port;
-        } else {
+        }
+        else
+        {
             std::cerr << "Unable to open serial port";
             has_error_ = true;
             return;
         }
-        std::cout << "Try to open serial port at " << serial_port_try << std::endl;
+        std::cout << "Try to open serial port at " << serial_port_try
+                  << std::endl;
         fd_ = open(serial_port_try.c_str(), O_RDWR | O_NOCTTY | O_NDELAY);
-        if (fd_ != -1) {
-            std::cout << "Opened serial port at " << serial_port_try << std::endl;
+        if (fd_ != -1)
+        {
+            std::cout << "Opened serial port at " << serial_port_try
+                      << std::endl;
             break;
         }
     }
 
     struct termios options;
 
-    fcntl(fd_, F_SETFL, FNDELAY);                    // Open the device in nonblocking mode
+    fcntl(fd_, F_SETFL, FNDELAY);  // Open the device in nonblocking mode
 
     // Set parameters
-    tcgetattr(fd_, &options);                        // Get the current options of the port
-    bzero(&options, sizeof(options));               // Clear all the options
-    speed_t         Speed = B115200;
-    cfsetispeed(&options, Speed);                   // Set the baud rate at 115200 bauds
+    tcgetattr(fd_, &options);          // Get the current options of the port
+    bzero(&options, sizeof(options));  // Clear all the options
+    speed_t Speed = B115200;
+    cfsetispeed(&options, Speed);  // Set the baud rate at 115200 bauds
     cfsetospeed(&options, Speed);
-    options.c_cflag |= ( CLOCAL | CREAD |  CS8);    // Configure the device : 8 bits, no parity, no control
-    options.c_iflag |= ( IGNPAR | IGNBRK );
-    options.c_cc[VTIME]=0;                          // Timer unused
-    options.c_cc[VMIN]=0;                           // At least on character before satisfy reading
-    tcsetattr(fd_, TCSANOW, &options);               // Activate the settings
+    options.c_cflag |=
+        (CLOCAL | CREAD |
+         CS8);  // Configure the device : 8 bits, no parity, no control
+    options.c_iflag |= (IGNPAR | IGNBRK);
+    options.c_cc[VTIME] = 0;  // Timer unused
+    options.c_cc[VMIN] = 0;   // At least on character before satisfy reading
+    tcsetattr(fd_, TCSANOW, &options);  // Activate the settings
 
     latest_values_.resize(num_values);
 
@@ -85,12 +101,15 @@ void SerialReader::loop()
     int line_index = 0;
 
     is_active_ = true;
-    while (is_loop_active_) {
+    while (is_loop_active_)
+    {
         int byte_consumed = 0;
         byte_read = read(fd_, buffer, buffer_size);
-        while (byte_consumed < byte_read) {
+        while (byte_consumed < byte_read)
+        {
             line[line_index++] = buffer[byte_consumed++];
-            if (buffer[byte_consumed - 1] == '\n') {
+            if (buffer[byte_consumed - 1] == '\n')
+            {
                 // Ignore the "\r\n" in the string.
                 line[line_index - 1] = '\0';
                 line[line_index - 2] = '\0';
@@ -101,9 +120,14 @@ void SerialReader::loop()
                 int bytes_scanned;
                 int number;
                 mutex_.lock();
-                for (std::size_t i = 0; i < latest_values_.size(); i++) {
-                    sscanf(line + bytes_scanned_total, "%d %n", &number, &bytes_scanned);
-                    if (bytes_scanned_total >= line_index) {
+                for (std::size_t i = 0; i < latest_values_.size(); i++)
+                {
+                    sscanf(line + bytes_scanned_total,
+                           "%d %n",
+                           &number,
+                           &bytes_scanned);
+                    if (bytes_scanned_total >= line_index)
+                    {
                         break;
                     }
                     bytes_scanned_total += bytes_scanned;
@@ -126,12 +150,15 @@ SerialReader::~SerialReader()
     close(fd_);
 }
 
-int SerialReader::fill_vector(std::vector<int>& values)
+int SerialReader::fill_vector(std::vector<int> &values)
 {
     mutex_.lock();
-    if (new_data_counter_ == 0) {
+    if (new_data_counter_ == 0)
+    {
         missed_data_counter_ += 1;
-    } else {
+    }
+    else
+    {
         missed_data_counter_ = 0;
     }
     new_data_counter_ = 0;
@@ -141,4 +168,4 @@ int SerialReader::fill_vector(std::vector<int>& values)
     return missed_data_counter_;
 }
 
-} // namespace blmc_drivers
+}  // namespace slider_box


### PR DESCRIPTION
## Description

The old behaviour was to always first attempt to auto-detect and only consider the port provided by the user if this fails.  The new behaviour depends on the value of the `serial_port` argument:

- Empty or "auto": Try to auto-detect the port.
- any other value: Try to open the specified port.  Do not attempt to auto-detect.

In either case, failure to open the port results in an exception (instead of just printing an error to the terminal), so it cannot be missed by the user.

This follows the discussion in https://github.com/open-dynamic-robot-initiative/solo/issues/118

Note that **this is a breaking change**, i.e. existing configurations will likely need to be updated.  I tried to make the corresponding error message informative, so people understand what they need to change.

This PR also contains a bunch of auto-reformatting on unrelated parts of the code.  I put this in a separate commit, so it can be excluded from review.

## How I Tested

On the test bench, trying all combinations.



## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
